### PR TITLE
Ignore files in the obj/ folder

### DIFF
--- a/src/Adfc.Msbuild/Adfc.Msbuild.csproj
+++ b/src/Adfc.Msbuild/Adfc.Msbuild.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
     <BuildOutputTargetFolder>build</BuildOutputTargetFolder>
-    <Version>0.1.0-prerelease</Version>
+    <Version>0.1.0-preview</Version>
     <PackageLicenseUrl>https://github.com/ADFCommunity/Adfc.Msbuild/blob/develop/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/ADFCommunity/Home</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ADFCommunity/Adfc.Msbuild</RepositoryUrl>

--- a/src/Adfc.Msbuild/build/Adfc.Msbuild.targets
+++ b/src/Adfc.Msbuild/build/Adfc.Msbuild.targets
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Json Include="**/*.json" Exclude="$(BaseOutputPath)**" />
+    <!-- todo: fix the excludes -->
+    <Json Include="**/*.json" Exclude="$(BaseOutputPath)**;obj\**" />
   </ItemGroup>
 
   <UsingTask 


### PR DESCRIPTION
When using the version of MSBuild that comes with VS2017, particularly when using package references, it writes some files (including json files) to the obj/ directory. These should be ignored. Also change the nuget package to preview instead of prerelease.