### PR TITLE
Build solution that contains adfc projects

### DIFF
--- a/samples/OneConfig/OneConfig.proj
+++ b/samples/OneConfig/OneConfig.proj
@@ -1,4 +1,3 @@
 <Project>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
-    <Import Project="..\..\src\Adfc.Msbuild\bin\Debug\Adfc.Msbuild.targets" />
+  <Import Project="..\Samples.props" />
 </Project>

--- a/samples/OneConfig/OneConfig.sln
+++ b/samples/OneConfig/OneConfig.sln
@@ -1,0 +1,34 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OneConfig", "OneConfig.proj", "{835F7651-00DD-466E-BBAF-7FF2B6F7E68E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{835F7651-00DD-466E-BBAF-7FF2B6F7E68E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{835F7651-00DD-466E-BBAF-7FF2B6F7E68E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{835F7651-00DD-466E-BBAF-7FF2B6F7E68E}.Debug|x64.ActiveCfg = Debug|x64
+		{835F7651-00DD-466E-BBAF-7FF2B6F7E68E}.Debug|x64.Build.0 = Debug|x64
+		{835F7651-00DD-466E-BBAF-7FF2B6F7E68E}.Debug|x86.ActiveCfg = Debug|x86
+		{835F7651-00DD-466E-BBAF-7FF2B6F7E68E}.Debug|x86.Build.0 = Debug|x86
+		{835F7651-00DD-466E-BBAF-7FF2B6F7E68E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{835F7651-00DD-466E-BBAF-7FF2B6F7E68E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{835F7651-00DD-466E-BBAF-7FF2B6F7E68E}.Release|x64.ActiveCfg = Release|x64
+		{835F7651-00DD-466E-BBAF-7FF2B6F7E68E}.Release|x64.Build.0 = Release|x64
+		{835F7651-00DD-466E-BBAF-7FF2B6F7E68E}.Release|x86.ActiveCfg = Release|x86
+		{835F7651-00DD-466E-BBAF-7FF2B6F7E68E}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+EndGlobal

--- a/samples/Samples.props
+++ b/samples/Samples.props
@@ -1,0 +1,5 @@
+<Project>
+    <Import Project="..\src\Adfc.Msbuild\bin\Debug\Adfc.Msbuild.props" />
+    <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+    <Import Project="..\src\Adfc.Msbuild\bin\Debug\Adfc.Msbuild.targets" />
+</Project>

--- a/src/Adfc.Msbuild/Adfc.Msbuild.csproj
+++ b/src/Adfc.Msbuild/Adfc.Msbuild.csproj
@@ -40,6 +40,7 @@
 
   <Target AfterTargets="Build" Name="CopyAdfcMsbuildFiles">
     <Copy SourceFiles="build/Adfc.Msbuild.targets" DestinationFolder="$(PackageOutputPath)" />
+    <Copy SourceFiles="build/Adfc.Msbuild.props" DestinationFolder="$(PackageOutputPath)" />
   </Target>
 
   <Target Name="PackTaskDependencies" BeforeTargets="GenerateNuspec">

--- a/src/Adfc.Msbuild/build/Adfc.Msbuild.props
+++ b/src/Adfc.Msbuild/build/Adfc.Msbuild.props
@@ -1,0 +1,7 @@
+﻿<Project>
+  <PropertyGroup>
+    <BaseOutputPath>bin\</BaseOutputPath>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <OutputPath>$(BaseOutputPath)$(Configuration)\</OutputPath>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
For some reason MSBuild behaves differently, with regards to automatic properties, when building a single project directly, or building a project as part of a solution. This commit adds a props file to nuget package, that adds the properties that do not get added automatically by the common msbuild targets file when building a solution.