### PR TITLE
Fix output messages

### DIFF
--- a/src/Adfc.Msbuild/AdfcBuild.cs
+++ b/src/Adfc.Msbuild/AdfcBuild.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -133,18 +133,18 @@ namespace Adfc.Msbuild
             switch (severity)
             {
                 case ErrorSeverity.Information:
-                    Log.LogMessage("ADFBuild", error.Code, "help keyword", error.FileName, error.LineNumber, error.LinePosition,
-                        error.LineNumber, error.LinePosition, error.Message);
+                    Log.LogMessage("ADFBuild", error.Code, "help keyword", error.FileName, error.LineNumber ?? 0, error.LinePosition ?? 0,
+                        error.LineNumber ?? 0, error.LinePosition ?? 0, error.Message);
                     break;
 
                 case ErrorSeverity.Warning:
-                    Log.LogWarning("ADFBuild", error.Code, "help keyword", error.FileName, error.LineNumber, error.LinePosition,
-                        error.LineNumber, error.LinePosition, error.Message);
+                    Log.LogWarning("ADFBuild", error.Code, "help keyword", error.FileName, error.LineNumber ?? 0, error.LinePosition ?? 0,
+                        error.LineNumber ?? 0, error.LinePosition ?? 0, message: error.Message);
                     break;
 
                 case ErrorSeverity.Error:
-                    Log.LogError("ADFBuild", error.Code, "help keyword", error.FileName, error.LineNumber, error.LinePosition,
-                        error.LineNumber, error.LinePosition, error.Message);
+                    Log.LogError("ADFBuild", error.Code, "help keyword", error.FileName, error.LineNumber ?? 0, error.LinePosition ?? 0,
+                        error.LineNumber ?? 0, error.LinePosition ?? 0, error.Message, (object[])null);
                     break;
             }
         }


### PR DESCRIPTION
When there were info, warning or error messages, instead of displayig the correct message, it was using the wrong overload and just writing "ADFBuild". This was due to the intended overload expecting some `int`s, but `int?`s were being passed. Using the null-coalescing operator fixed the issue.