### PR TITLE
Move file globs to props file

### DIFF
--- a/src/Adfc.Msbuild/build/Adfc.Msbuild.props
+++ b/src/Adfc.Msbuild/build/Adfc.Msbuild.props
@@ -1,7 +1,12 @@
 ﻿<Project>
   <PropertyGroup>
-    <BaseOutputPath>bin\</BaseOutputPath>
+    <BaseIntermediatePath Condition="'$(BaseIntermediatePath)' == ''">obj\</BaseIntermediatePath>
+    <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">bin\</BaseOutputPath>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <OutputPath>$(BaseOutputPath)$(Configuration)\</OutputPath>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Json Include="**/*.json" Exclude="$(BaseOutputPath)**;$(BaseIntermediatePath)**" />
+  </ItemGroup>
 </Project>

--- a/src/Adfc.Msbuild/build/Adfc.Msbuild.targets
+++ b/src/Adfc.Msbuild/build/Adfc.Msbuild.targets
@@ -1,14 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project>
-  <PropertyGroup>
-    <BaseOutputPath Condition="'$(BaseOutputPath)'==''">bin/</BaseOutputPath>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <!-- todo: fix the excludes -->
-    <Json Include="**/*.json" Exclude="$(BaseOutputPath)**;obj\**" />
-  </ItemGroup>
-
   <UsingTask 
     TaskName="Adfc.Msbuild.AdfcBuild"
     AssemblyFile="$(MSBuildThisFileDirectory)net46/Adfc.Msbuild.dll"/>


### PR DESCRIPTION
As advised in Microsoft/VSProjectSystem#244:
Also, it is recommended to put globs in .props. This way CPS can make use of the msbuild Update element to selectively edit a globbed items metadata in the middle of the project file, and not have to add items below the .targets imports.