### PR TITLE
Mark references as private, so they're not nuget dependencies

### DIFF
--- a/src/Adfc.Msbuild.Tests/Adfc.Msbuild.Tests.csproj
+++ b/src/Adfc.Msbuild.Tests/Adfc.Msbuild.Tests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Adfc.Msbuild/Adfc.Msbuild.csproj
+++ b/src/Adfc.Msbuild/Adfc.Msbuild.csproj
@@ -24,20 +24,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.409" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" PrivateAssets="All" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="Microsoft.Build" />
-    <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Utilities.v4.0" />
-  </ItemGroup>
-
+  <!-- include build files in nuget package -->
   <ItemGroup>
     <Content Include="build\**" PackagePath="build\" />
   </ItemGroup>
 
+  <!-- copy build files to bin directory, so the relative paths they contain to adfc.msbuild.dll work
+       and we can directly import them from other msbuild files to easily test the debug build. -->
   <Target AfterTargets="Build" Name="CopyAdfcMsbuildFiles">
     <Copy SourceFiles="build/Adfc.Msbuild.targets" DestinationFolder="$(PackageOutputPath)" />
     <Copy SourceFiles="build/Adfc.Msbuild.props" DestinationFolder="$(PackageOutputPath)" />


### PR DESCRIPTION
closes #24 