### PR TITLE
Add unique name validator

### DIFF
--- a/src/Adfc.Msbuild.Tests/JsonFileLoaderTests.cs
+++ b/src/Adfc.Msbuild.Tests/JsonFileLoaderTests.cs
@@ -21,7 +21,7 @@ namespace Adfc.Msbuild.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual("file.json", result.Identity);
             Assert.AreEqual(ArtefactCategory.Dataset, result.Category);
-            Assert.AreEqual("test", result.Name);
+            Assert.AreEqual("TestDataset", result.Name);
             Assert.IsNotNull(result.Json);
             Assert.AreEqual(0, target.Errors.Count);
         }
@@ -39,7 +39,7 @@ namespace Adfc.Msbuild.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual("file.json", result.Identity);
             Assert.AreEqual(ArtefactCategory.LinkedService, result.Category);
-            Assert.AreEqual("test", result.Name);
+            Assert.AreEqual("TestLinkedService", result.Name);
             Assert.IsNotNull(result.Json);
             Assert.AreEqual(0, target.Errors.Count);
         }
@@ -57,7 +57,7 @@ namespace Adfc.Msbuild.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual("file.json", result.Identity);
             Assert.AreEqual(ArtefactCategory.Pipeline, result.Category);
-            Assert.AreEqual("test", result.Name);
+            Assert.AreEqual("TestPipeline", result.Name);
             Assert.IsNotNull(result.Json);
             Assert.AreEqual(0, target.Errors.Count);
         }

--- a/src/Adfc.Msbuild.Tests/JsonSample.cs
+++ b/src/Adfc.Msbuild.Tests/JsonSample.cs
@@ -2,11 +2,11 @@ namespace Adfc.Msbuild.Tests
 {
     public class JsonSample
     {
-        public const string Dataset = "{'name':'test','$schema':'http://datafactories.schema.management.azure.com/schemas/2015-09-01/Microsoft.DataFactory.Table.json'}";
+        public const string Dataset = "{'name':'TestDataset','$schema':'http://datafactories.schema.management.azure.com/schemas/2015-09-01/Microsoft.DataFactory.Table.json'}";
 
-        public const string LinkedService = "{'name':'test','$schema':'http://datafactories.schema.management.azure.com/schemas/2015-09-01/Microsoft.DataFactory.LinkedService.json'}";
+        public const string LinkedService = "{'name':'TestLinkedService','$schema':'http://datafactories.schema.management.azure.com/schemas/2015-09-01/Microsoft.DataFactory.LinkedService.json'}";
 
-        public const string Pipeline = "{'name':'test','$schema':'http://datafactories.schema.management.azure.com/schemas/2015-09-01/Microsoft.DataFactory.Pipeline.json'}";
+        public const string Pipeline = "{'name':'TestPipeline','$schema':'http://datafactories.schema.management.azure.com/schemas/2015-09-01/Microsoft.DataFactory.Pipeline.json'}";
 
         public const string Config = "{'$schema':'http://datafactories.schema.management.azure.com/vsschemas/V1/Microsoft.DataFactory.Config.json'}";
     }

--- a/src/Adfc.Msbuild.Tests/Validation/JsonSchemaValidationTests.cs
+++ b/src/Adfc.Msbuild.Tests/Validation/JsonSchemaValidationTests.cs
@@ -1,11 +1,10 @@
-using System;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
+using Adfc.Msbuild.Validation;
 
-namespace Adfc.Msbuild.Tests
+namespace Adfc.Msbuild.Tests.Validation
 {
     [TestClass]
     public class JsonSchemaValidationTests

--- a/src/Adfc.Msbuild.Tests/Validation/UniqueNameValidationTests.cs
+++ b/src/Adfc.Msbuild.Tests/Validation/UniqueNameValidationTests.cs
@@ -1,0 +1,97 @@
+using Adfc.Msbuild.Validation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Adfc.Msbuild.Tests.Validation
+{
+    [TestClass]
+    public class UniqueNameValidationTests
+    {
+        [TestMethod]
+        public async Task ShouldValidateEmptyList()
+        {
+            var artefacts = new List<JsonFile>();
+
+            var target = new UniqueNameValidation();
+
+            var result = await target.ValidateAsync(artefacts);
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public async Task ShouldValidateSingleArtefact()
+        {
+            var artefacts = new List<JsonFile>()
+            {
+                await Util.LoadJsonAsync("file.json", JsonSample.LinkedService)
+            };
+
+            var target = new UniqueNameValidation();
+
+            var result = await target.ValidateAsync(artefacts);
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public async Task ShouldValidateArtefactsWithUniqueNames()
+        {
+            var artefacts = new List<JsonFile>()
+            {
+                await Util.LoadJsonAsync("linkedservice.json", JsonSample.LinkedService),
+                await Util.LoadJsonAsync("dataset.json", JsonSample.Dataset),
+                await Util.LoadJsonAsync("pipeline.json", JsonSample.Pipeline)
+            };
+
+            var target = new UniqueNameValidation();
+
+            var result = await target.ValidateAsync(artefacts);
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public async Task ShouldReportErrorWhenTwoArtefactsHaveSameName()
+        {
+            var artefacts = new List<JsonFile>()
+            {
+                await Util.LoadJsonAsync("file1.json", JsonSample.Dataset),
+                await Util.LoadJsonAsync("file2.json", JsonSample.Dataset)
+            };
+
+            var target = new UniqueNameValidation();
+
+            var result = await target.ValidateAsync(artefacts);
+
+            Assert.AreEqual(2, result.Count);
+
+            var error = result.FirstOrDefault(r => r.FileName == "file1.json");
+            Assert.IsNotNull(error);
+            Assert.AreEqual(ErrorCodes.Adfc0008.Code, error.Code);
+
+            error = result.FirstOrDefault(r => r.FileName == "file2.json");
+            Assert.IsNotNull(error);
+            Assert.AreEqual(ErrorCodes.Adfc0008.Code, error.Code);
+        }
+
+        [TestMethod]
+        public async Task ShouldAllowArtefactsOfDifferentCategoryToUseSameName()
+        {
+            var artefacts = new List<JsonFile>()
+            {
+                new JsonFile("test", "file1.json", new JObject(new JProperty("name", "test")), ArtefactCategory.Dataset),
+                new JsonFile("test", "file2.json", new JObject(new JProperty("name", "test")), ArtefactCategory.LinkedService)
+            };
+
+            var target = new UniqueNameValidation();
+
+            var result = await target.ValidateAsync(artefacts);
+
+            Assert.AreEqual(0, result.Count);
+        }
+    }
+}

--- a/src/Adfc.Msbuild/ErrorCodes.cs
+++ b/src/Adfc.Msbuild/ErrorCodes.cs
@@ -23,11 +23,14 @@ namespace Adfc.Msbuild
         /// <summary>Failed implicit JSON schema validation.</summary>
         public static readonly ErrorCodes Adfc0006 = new ErrorCodes("ADFC0006", ErrorSeverity.Error);
 
-        /// <summary>Error during JSON validation.</summary>
+        /// <summary>Error during JSON schema validation.</summary>
         public static readonly ErrorCodes Adfc0007 = new ErrorCodes("ADFC0007", ErrorSeverity.Error);
 
+        /// <summary>Artefact name is not unique.</summary>
+        public static readonly ErrorCodes Adfc0008 = new ErrorCodes("ADFC0008", ErrorSeverity.Error);
+
         public static IReadOnlyDictionary<string, ErrorCodes> All =
-            new[] { Adfc0001, Adfc0002, Adfc0003, Adfc0004, Adfc0005, Adfc0006, Adfc0007 }
+            new[] { Adfc0001, Adfc0002, Adfc0003, Adfc0004, Adfc0005, Adfc0006, Adfc0007, Adfc0008 }
             .ToDictionary(e => e.Code, e => e);
 
         public string Code { get; }

--- a/src/Adfc.Msbuild/Validation/IValidation.cs
+++ b/src/Adfc.Msbuild/Validation/IValidation.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Adfc.Msbuild.Validation
+{
+    public interface IValidation
+    {
+        Task<IReadOnlyCollection<BuildError>> ValidateAsync(IList<JsonFile> artefacts);
+    }
+}

--- a/src/Adfc.Msbuild/Validation/JsonSchemaValidation.cs
+++ b/src/Adfc.Msbuild/Validation/JsonSchemaValidation.cs
@@ -4,16 +4,31 @@ using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NJsonSchema;
+using System.Collections.Generic;
 
-namespace Adfc.Msbuild
+namespace Adfc.Msbuild.Validation
 {
-    public class JsonSchemaValidation
+    public class JsonSchemaValidation : IValidation
     {
         private HttpClient _httpClient;
 
         public JsonSchemaValidation(HttpClient httpClient)
         {
             _httpClient = httpClient;
+        }
+
+        public async Task<IReadOnlyCollection<BuildError>> ValidateAsync(IList<JsonFile> jsonFiles)
+        {
+            var errors = new List<BuildError>();
+            foreach (var jsonFile in jsonFiles)
+            {
+                var result = await ValidateAsync(jsonFile);
+                if (result != null)
+                {
+                    errors.Add(result);
+                }
+            }
+            return errors;
         }
 
         public async Task<BuildError> ValidateAsync(JsonFile jsonFile)

--- a/src/Adfc.Msbuild/Validation/UniqueNameValidation.cs
+++ b/src/Adfc.Msbuild/Validation/UniqueNameValidation.cs
@@ -1,0 +1,41 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Adfc.Msbuild.Validation
+{
+    public class UniqueNameValidation : IValidation
+    {
+        public Task<IReadOnlyCollection<BuildError>> ValidateAsync(IList<JsonFile> artefacts)
+        {
+            var errors = new List<BuildError>();
+
+            foreach (var artefactsPerCategory in artefacts.GroupBy(a => a.Category))
+            {
+                foreach (var artefactsByName in artefactsPerCategory.GroupBy(a => a.Name))
+                {
+                    if (artefactsByName.Count() > 1)
+                    {
+                        foreach (var artefact in artefactsByName)
+                        {
+                            var nameToken = artefact.Json["name"];
+                            var lineInfo = nameToken as IJsonLineInfo;
+                            var error = new BuildError
+                            {
+                                Code = ErrorCodes.Adfc0008.Code,
+                                Message = $"More than one {artefact.Category} named {artefact.Name}",
+                                FileName = artefact.Identity,
+                                LineNumber = lineInfo?.LineNumber,
+                                LinePosition = lineInfo?.LinePosition
+                            };
+                            errors.Add(error);
+                        }
+                    }
+                }
+            }
+
+            return Task.FromResult<IReadOnlyCollection<BuildError>>(errors);
+        }
+    }
+}

--- a/src/Adfc.Msbuild/Validation/ValidationsFactory.cs
+++ b/src/Adfc.Msbuild/Validation/ValidationsFactory.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace Adfc.Msbuild.Validation
+{
+    public class ValidationsFactory
+    {
+        private HttpClient _httpClient;
+
+        public ValidationsFactory(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public IReadOnlyList<IValidation> GetValidators()
+        {
+            List<IValidation> validators = new List<IValidation>()
+            {
+                new JsonSchemaValidation(_httpClient),
+                new UniqueNameValidation()
+            };
+            return validators;
+        }
+    }
+}


### PR DESCRIPTION
ADF rejects creating a new artefact if there is already an artefact with the same name of the same category. Also did a little refactoring to make create a validation interface, so the build task can loop though a list of validators.

closes #3 
